### PR TITLE
Avoid misclassifying inline csv blocks as submissions

### DIFF
--- a/.github/workflows/hrr_intake.yml
+++ b/.github/workflows/hrr_intake.yml
@@ -91,23 +91,40 @@ jobs:
           run_id = os.environ.get("GITHUB_RUN_ID","" ).strip()
           TOKEN = os.environ.get("GITHUB_TOKEN","").strip()
           SUBMISSION_COL = "SubmissionKey"
+          CANONICAL_HEADER = "id,scource in ideee,time unit,energy unit,topic,filename"
+          CANONICAL_FIELDS = CANONICAL_HEADER.split(",")
 
           # ---------- Helpers ----------
+          def is_submission_header(line: str) -> bool:
+              normalized = re.sub(r"\s*,\s*", ",", line.strip().lower())
+              fields = normalized.split(",")
+              if len(fields) < len(CANONICAL_FIELDS):
+                  return False
+              for expected, actual in zip(CANONICAL_FIELDS, fields):
+                  if actual != expected:
+                      return False
+              return True
+
           def find_csv_block(text: str) -> str:
-              # Prefer fenced code block ```csv ... ```
-              m = re.search(r"```(?:csv)?\s*([\s\S]*?)\s*```", text, flags=re.I)
-              if m:
-                  return m.group(1).strip()
+              # Prefer fenced code block ```csv ... ``` but ensure it contains the metadata header
+              for m in re.finditer(r"```([^\n]*)\n([\s\S]*?)```", text, flags=re.I):
+                  info = (m.group(1) or "").strip().lower()
+                  if "csv" not in info:
+                      continue
+                  block = m.group(2).strip()
+                  first_line = next((ln for ln in block.splitlines() if ln.strip()), "")
+                  if first_line and is_submission_header(first_line):
+                      return block
               # Fallback: locate header anywhere, then collect CSV-looking lines
               lines = text.splitlines()
-              canonical = "id,scource in ideee,time unit,energy unit,topic,filename"
-              canonical_nospace = re.sub(r"\s+", "", canonical)
+              canonical_nospace = re.sub(r"\s+", "", CANONICAL_HEADER)
               start = None
               for i, line in enumerate(lines):
                   raw = line.strip().lower()
-                  if not raw: continue
+                  if not raw:
+                      continue
                   norm = re.sub(r"\s*,\s*", ",", raw)
-                  if norm == canonical or re.sub(r"\s+", "", raw) == canonical_nospace:
+                  if norm == CANONICAL_HEADER or re.sub(r"\s+", "", raw) == canonical_nospace:
                       start = i; break
               if start is None: return ""
               out = [re.sub(r"\s*,\s*", ",", lines[start].strip())]


### PR DESCRIPTION
## Summary
- ensure the workflow only treats fenced `csv` blocks that contain the canonical metadata header as the submission CSV, allowing inline raw files to coexist with labeled blocks
- reuse the canonical header definition across the CSV detection logic so the fallback scan remains consistent

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691619a9cb70832e9143228dd303af65)