### PR TITLE
Integrate IEEE DOI/ISBN conversion into workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# HrrKit utilities
+
+This repository contains scripts that support the HRRkit workflow. The main entry
+point is `hrrkit_excel.py`, which ingests the `database.csv` table, moves raw
+curves into the canonical folder structure, and produces the derived outputs
+listed in the module docstring.
+
+## IEEE source formatting inside `database.csv`
+
+The `Scource in IDEEE` column accepts either a fully formatted IEEE reference or
+an identifier that the script can expand on your behalf:
+
+- **DOIs** – accepted forms: `doi:10.1109/5.771073`, `https://doi.org/10.1109/5.771073`, or a raw `10.xxxx/yyy` string.
+- **ISBNs** – accepted forms: `isbn:9780131101630`, `ISBN 0-201-53082-1`, or a plain 10/13 digit value with optional hyphens.
+
+When one of these patterns is detected the script resolves the identifier and
+replaces the `Scource in IDEEE` value with an IEEE-formatted reference. This
+updated value is stored in `database.csv`, the per-topic source registry, and the
+plot captions, so the user only has to provide the DOI/ISBN once.
+
+Network access is required for DOI lookups, while ISBN metadata is collected via
+[`isbnlib`](https://pypi.org/project/isbnlib/). Install the dependencies with:
+
+```bash
+pip install requests isbnlib
+```


### PR DESCRIPTION
## Summary
- add DOI/ISBN detection utilities to `hrrkit_excel.py` so `Scource in IDEEE` values can be supplied as identifiers and are converted to IEEE formatted citations during processing
- update the database writing logic so the resolved citation is stored everywhere the source is persisted and provide console feedback when a conversion succeeds or fails
- document the built-in conversion option in the README and remove the standalone citation helper script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916199849d4832e827eee8a2eb5cc2a)