### PR TITLE
Fix heredoc delimiter in workflow

### DIFF
--- a/.github/workflows/hrr_intake.yml
+++ b/.github/workflows/hrr_intake.yml
@@ -589,7 +589,7 @@ jobs:
           Path('validation_summary.md').write_text(summary, encoding='utf-8')
           with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
               fh.write(f"status={status}\n")
-              fh.write("summary<<'EOF'\n")
+              fh.write("summary<<EOF\n")
               fh.write(summary)
               fh.write("EOF\n")
           PY


### PR DESCRIPTION
## Summary
- fix the validation summary step so it writes its multiline output using a valid heredoc delimiter

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919cb44f080832eaa980e2610d65da5)