### PR TITLE
Clarify pending-row guidance

### DIFF
--- a/.github/workflows/hrr_intake.yml
+++ b/.github/workflows/hrr_intake.yml
@@ -173,6 +173,9 @@ jobs:
               if not rows:
                   lines.append('')
                   lines.append('No pending rows were found in database.csv.')
+                  lines.append('')
+                  lines.append('This usually means the intake issue did not include any ID/Topic blocks or every row was already processed.')
+                  lines.append('Update the issue to include at least one ID/Topic block using the intake template, then rerun `/validate` so the workflow can import the pending rows automatically.')
               else:
                   for row in rows:
                       indicator = '✅' if row.get('status') == 'ok' else '❌'


### PR DESCRIPTION
## Summary
- update the validation summary text shown when no pending rows exist so it tells contributors to update the intake issue with the template
- highlight that the workflow automatically imports pending rows after they update the issue and rerun `/validate`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919db948360832ea220325153c6ed59)