### PR TITLE
Handle bold field labels in issue intake

### DIFF
--- a/issue_intake.py
+++ b/issue_intake.py
@@ -91,7 +91,16 @@ def find_csv_block(text: str) -> str:
 
 
 def normalize_key(name: str) -> str:
-    return re.sub(r"\s+", " ", (name or "").strip().lower())
+    """Return a canonical representation for template field names."""
+
+    cleaned = (name or "").strip().lower()
+    # Issue forms often wrap field names in Markdown emphasis (e.g. "**ID**")
+    # or prefix them with bullets. Strip those wrapper characters while
+    # keeping meaningful punctuation such as parentheses.
+    cleaned = re.sub(r"^[\s>\-*_`•]+", "", cleaned)
+    cleaned = re.sub(r"[\s>\-*_`•]+$", "", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned
 
 
 def parse_structured_blocks(text: str) -> List[Dict[str, str]]:
@@ -124,7 +133,7 @@ def parse_structured_blocks(text: str) -> List[Dict[str, str]]:
         if not stripped:
             flush_current()
             continue
-        if stripped.startswith("###") or stripped.startswith("**"):
+        if stripped.startswith("###"):
             continue
         if ":" not in stripped:
             continue


### PR DESCRIPTION
## Summary
- allow the structured issue parser to understand field names that are wrapped in Markdown emphasis or prefixed with list markers
- add normalization so the new formatting still maps to the required ID/Topic fields

## Testing
- python - <<'PY'
import types, sys, textwrap
sys.modules['pandas'] = types.ModuleType('pandas')
requests_stub = types.ModuleType('requests')
requests_stub.get = lambda *args, **kwargs: None
sys.modules['requests'] = requests_stub
import issue_intake
body = textwrap.dedent('''
File details for database.csv

**ID**: 1
**Scource in IDEEE**: 10.1016/j.firesaf.2025.104558
**Topic**: car
**Time Unit**: min
**Energy Unit**: kW
**Attachment filename**: CAR_2010_Test03.csv

- **ID**: 2
- **Scource in IDEEE**: 10.1007/s10694-025-01725-x
- **Topic**: car
- **Time Unit**: min
- **Energy Unit**: kW
- **Attachment filename**: CAR_2010_Test04.csv
''')
rows = issue_intake.parse_rows(body)
print(rows)
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919e0dd9988832e87f8f4db8573527c)