### PR TITLE
Handle CSV attachments with query params

### DIFF
--- a/issue_intake.py
+++ b/issue_intake.py
@@ -423,7 +423,9 @@ def ingest_issue(body: str, issue_number: str, run_id: str, token: str, database
 
     raw_dir.mkdir(parents=True, exist_ok=True)
     attachments = []
-    attachment_pattern = re.compile(r"\((https?://[^\s)]+\.csv)\)", flags=re.I)
+    attachment_pattern = re.compile(
+        r"\((https?://[^\s)]+\.(?:csv|txt)(?:\?[^\s)]*)?)\)", flags=re.I
+    )
     for url in attachment_pattern.findall(body):
         clean_url = url.strip()
         name = pathlib.Path(clean_url.split("?")[0]).name

--- a/tests/test_issue_intake.py
+++ b/tests/test_issue_intake.py
@@ -1,0 +1,65 @@
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import issue_intake
+
+
+def _build_issue_body() -> str:
+    return """File details for database.csv
+
+ID: 1
+Scource in IDEEE: 10.1016/j.firesaf.2025.104558
+Topic: car
+Time Unit: min
+Energy Unit: kW
+Attachment filename: CAR_2010_Test03.csv
+
+ID: 2
+Scource in IDEEE: 10.1007/s10694-025-01725-x
+Topic: car
+Time Unit: min
+Energy Unit: kW
+Attachment filename: CAR_2010_Test04.csv
+
+[CAR_2010_Test03.csv](https://example.com/files/CAR_2010_Test03.csv?download=1)
+[CAR_2010_Test04.csv](https://example.com/files/CAR_2010_Test04.csv?raw=1)
+"""
+
+
+def test_ingest_issue_accepts_csv_links_with_query(tmp_path, monkeypatch):
+    downloads = []
+
+    def fake_download(url: str, dest: Path, token: str) -> bool:
+        downloads.append(url)
+        dest.write_text("time,hrr\n0,0\n")
+        return True
+
+    monkeypatch.setattr(issue_intake, "download_with_auth", fake_download)
+
+    database = tmp_path / "database.csv"
+    raw_dir = tmp_path / "raw"
+
+    added, updated = issue_intake.ingest_issue(
+        _build_issue_body(),
+        issue_number="42",
+        run_id="123",
+        token="",
+        database_path=database,
+        raw_dir=raw_dir,
+    )
+
+    assert added == 2
+    assert updated == 0
+    assert len(downloads) == 2
+
+    with database.open() as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 2
+    for row in rows:
+        filename = row["Filename"]
+        assert filename
+        assert (raw_dir / filename).is_file()


### PR DESCRIPTION
## Summary
- allow the intake helper to match CSV/TXT attachment links even when GitHub appends download query parameters
- add a regression test that exercises ingest_issue with CSV links that contain query strings

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ecc7a324832e82c0200a69aa23ef)