### PR TITLE
Handle intake CSV blocks with filename attribute

### DIFF
--- a/tests/test_issue_intake.py
+++ b/tests/test_issue_intake.py
@@ -110,3 +110,13 @@ time,hrr
     with database.open() as handle:
         rows = list(csv.DictReader(handle))
     assert rows[0]["ID"] == "1"
+
+
+def test_find_csv_block_allows_metadata_block_with_filename_info():
+    body = """```csv filename=intake.csv
+ID,Scource in IDEEE,Time Unit,Energy Unit,Topic,Filename
+Row1,Source,s,kW,car,file.csv
+```"""
+
+    block = issue_intake.find_csv_block(body)
+    assert "Row1,Source" in block


### PR DESCRIPTION
## Summary
- allow intake CSV metadata blocks to be parsed even when their code fence info string includes a filename hint
- improve CSV fence detection to handle comma-delimited info strings and skip only non-metadata inline files
- add coverage for metadata blocks that use filename attributes

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692083601700832eb93972dd61e78bd9)