### PR TITLE
Prevent metadata CSV fences from being treated as raw files

### DIFF
--- a/issue_intake.py
+++ b/issue_intake.py
@@ -252,6 +252,10 @@ def extract_inline_files(body: str) -> Dict[str, str]:
                 filename = marker.group(1).strip()
                 content = "\n".join(rest) + ("\n" if rest else "")
         if filename:
+            first_content_line = next((line.strip() for line in content.splitlines() if line.strip()), "").lower()
+            normalized_header = _normalize_csv_header(first_content_line)
+            if _is_intake_header(normalized_header):
+                continue
             files[pathlib.Path(filename).name] = content
     return files
 

--- a/tests/test_issue_intake.py
+++ b/tests/test_issue_intake.py
@@ -2,6 +2,8 @@ import csv
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
@@ -120,3 +122,20 @@ Row1,Source,s,kW,car,file.csv
 
     block = issue_intake.find_csv_block(body)
     assert "Row1,Source" in block
+
+
+def test_ingest_issue_does_not_treat_metadata_block_as_raw(tmp_path):
+    body = """```csv filename=intake.csv
+ID,Scource in IDEEE,Time Unit,Energy Unit,Topic
+Row1,Source,s,kW,car
+```"""
+
+    with pytest.raises(issue_intake.IntakeError, match="Could not match any attachment"):
+        issue_intake.ingest_issue(
+            body,
+            issue_number="99",
+            run_id="123",
+            token="",
+            database_path=tmp_path / "database.csv",
+            raw_dir=tmp_path / "raw",
+        )


### PR DESCRIPTION
## Summary
- ignore intake metadata CSV fences when collecting inline file attachments
- add regression test ensuring metadata-only issues still fail without real raw files

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692087247c00832ea80082046b8749d9)